### PR TITLE
Additional max_chunksize paramter to do_put method

### DIFF
--- a/r/R/flight.R
+++ b/r/R/flight.R
@@ -56,9 +56,11 @@ flight_disconnect <- function(client) {
 #' @param overwrite logical: if `path` exists on `client` already, should we
 #' replace it with the contents of `data`? Default is `TRUE`; if `FALSE` and
 #' `path` exists, the function will error.
+#' @param max_chunksize integer: Maximum size for RecordBatch chunks when a `data.frame` is sent. 
+#' Individual chunks may be smaller depending on the chunk layout of individual columns.
 #' @return `client`, invisibly.
 #' @export
-flight_put <- function(client, data, path, overwrite = TRUE) {
+flight_put <- function(client, data, path, overwrite = TRUE, max_chunksize = NULL) {
   assert_is(data, c("data.frame", "Table", "RecordBatch"))
 
   if (!overwrite && flight_path_exists(client, path)) {
@@ -72,6 +74,8 @@ flight_put <- function(client, data, path, overwrite = TRUE) {
   writer <- client$do_put(descriptor_for_path(path), py_data$schema)[[1]]
   if (inherits(data, "RecordBatch")) {
     writer$write_batch(py_data)
+  } else if (!is.null(max_chunksize)) {
+    writer$write_table(py_data, max_chunksize)
   } else {
     writer$write_table(py_data)
   }


### PR DESCRIPTION
**Summary**
An additional parameter in Flight do_put to specify chunk size in R. 

**Problem**
Currently, all data is sent through in a single message. It's a likely scenario that users will want the ability to control the batch sizes without building a custom do_put method.

**Solution**
Additional (optional) parameter to specify chunk size.